### PR TITLE
Add installation step to usage notebook

### DIFF
--- a/notebooks/usage.ipynb
+++ b/notebooks/usage.ipynb
@@ -24,6 +24,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Install the mechint-demo package\n",
+    "!pip install -q git+https://github.com/sscardapane/mechint-demo.git\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from llm_runner import run_with_sae\n",
     "\n",
     "# Generate text with an SAE loaded from the Hugging Face Hub\n",


### PR DESCRIPTION
## Summary
- ensure Colab notebook installs the mechint-demo package for self-contained execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68931e3e0e948328adf739d0ad07994d