### PR TITLE
Pin required packages for notebook environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ optionally loading sparse autoencoders (SAEs) when available.
 ## Installation
 
 Install the utilities directly from the repository. Required dependencies
-(`torch`, `transformers`, and `accelerate`) will be installed automatically:
+(`torch`, `transformers`, `accelerate`, and supporting libraries such as
+`numpy` and `httpx`) will be installed automatically:
 
 ```
 pip install git+https://github.com/sscardapane/mechint-demo.git

--- a/llm_runner.py
+++ b/llm_runner.py
@@ -46,7 +46,11 @@ def run_with_sae(
     """
 
     if AutoModelForCausalLM is None or AutoTokenizer is None or torch is None:
-        raise ImportError("transformers and torch are required to run models")
+        raise ImportError(
+            "transformers and torch are required to run models. Install them with"
+            " `pip install mechint-demo` or `pip install torch transformers` before"
+            " calling `run_with_sae`."
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForCausalLM.from_pretrained(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,13 @@ readme = "README.md"
 authors = [{name = "Simone Scardapane"}]
 requires-python = ">=3.8"
 dependencies = [
-    "torch",
-    "transformers",
-    "accelerate",
+    "torch>=2.0",
+    "transformers>=4.40",
+    "accelerate>=0.30",
+    "numpy>=2.0",
+    "fsspec==2025.3.0",
+    "httpx>=0.28.1",
+    "zstandard>=0.23.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
## Summary
- pin numpy, httpx, fsspec and zstandard versions so installing `mechint-demo` no longer downgrades those packages in notebooks
- update README to explain that supporting libraries are installed automatically
- improve missing dependency message in `run_with_sae`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68934eb8c4e4832881ae545513a12fab