### PR TITLE
Fix dependency conflict with sae-lens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ dependencies = [
     "torch>=2.0",
     "transformers>=4.40",
     "accelerate>=0.30",
-    "numpy>=2.0",
-    "fsspec==2025.3.0",
+    "numpy>=1.26,<2.0",
+    "fsspec>=2023.9.2",
     "httpx>=0.28.1",
     "zstandard>=0.23.0",
 ]
@@ -23,4 +23,4 @@ dependencies = [
 py-modules = ["llm_runner"]
 
 [project.optional-dependencies]
-sae = ["sae-lens"]
+sae = ["sae-lens>=6.5.1"]


### PR DESCRIPTION
## Summary
- relax NumPy requirement and update fsspec to avoid conflict with sae-lens
- pin sae-lens extra to a compatible version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689358ed0ce48328b6767b40d233ce50